### PR TITLE
Making parameter list based on request from the client

### DIFF
--- a/susan/apps/dhcp/constants.py
+++ b/susan/apps/dhcp/constants.py
@@ -28,16 +28,35 @@ PORTS = utils.make_enum(
 
 
 OPTIONS = utils.make_enum(
+    # Vendor Extensions
     NETMASK=1,
-    DNS_SERVER=6,
     ROUTER=3,
+    TIME_SERVER=4,
+    NAME_SERVER=5,
+    DNS_SERVER=6,
+    LOG_SERVER=7,
+    HOST_NAME=12,
+    BOOT_FILE=13,
+    DOMAIN_NAME=15,
+    END=255,
+
+    # IP Layer parameter per interface
     MTU=26,
+    BROADCAST_ADDR=28,
+
+    # DHCP EXTENSIONS
     REQUESTED_IP=50,
     LEASE_TIME=51,
     MESSAGE_TYPE=53,
     SERVER_IDENTIFIER=54,
+    PARAMETER_REQUEST=55,
+    MESSAGE=56,
+    MAX_DHCP_SIZE=57,
+    RENEWEL_TIME=58,
+    REBINDING_TIME=59,
     CLIENT_IDENTIFIER=61,
-    TFTP_SERVER_NAME=66
+    TFTP_SERVER_NAME=66,
+    BOOT_FILE_NAME=67
 )
 
 

--- a/susan/apps/dhcp/dhcp.py
+++ b/susan/apps/dhcp/dhcp.py
@@ -109,12 +109,12 @@ class DHCPServer(object):
         opts = dhcp_pkt.options.option_list
         msg_type = dhcp_const.OPTIONS.MESSAGE_TYPE
         discover = struct.pack('!B', dhcp_const.REQUEST.DISCOVER)
-        offer = struct.pack('!B', dhcp_const.REQUEST.REQUEST)
+        request = struct.pack('!B', dhcp_const.REQUEST.REQUEST)
         for option in opts:
             if option.tag == msg_type and option.value == discover:
                 request_type = REQUEST_MAPPER.DHCPDISCOVER
                 break
-            elif option.tag == msg_type and option.value == offer:
+            elif option.tag == msg_type and option.value == request:
                 request_type = REQUEST_MAPPER.DHCPREQUEST
                 break
 

--- a/susan/apps/dhcp/dhcp.py
+++ b/susan/apps/dhcp/dhcp.py
@@ -18,6 +18,7 @@ from ryu.lib.packet import dhcp
 from ryu.lib.packet import ethernet
 
 from susan.apps.dhcp import constants as dhcp_const
+from susan.apps.dhcp import pack_option
 from susan.common import constants as const
 from susan.common import matcher
 from susan.common import packet as packet_util
@@ -30,6 +31,17 @@ SERVER_MAC = '16:b2:3b:34:24:77'
 YIP = '172.30.10.10'
 ROUTER = '172.30.10.1'
 LEASE_TIME = 10000
+
+
+def get_value(param):
+    mapper = {
+        dhcp_const.OPTIONS.LEASE_TIME: 100,
+        dhcp_const.OPTIONS.NETMASK: NETMASK,
+        dhcp_const.OPTIONS.ROUTER: ROUTER,
+        dhcp_const.OPTIONS.DNS_SERVER: '8.8.8.8',
+        dhcp_const.OPTIONS.SERVER_IDENTIFIER: SERVER_IP
+    }
+    return mapper.get(param, None)
 
 
 REQUEST_MAPPER = utils.make_enum(
@@ -53,9 +65,10 @@ class DHCPServer(object):
     @staticmethod
     def initialize(datapath):
         """Initialize DHCP application. It adds two flows
-           1. Move DHCP packet to table defined in constant module.
-           2. Move a DHCP Packet from DHCP table to controller.
+          1. Move DHCP packet to table defined in constant module.
+          2. Move a DHCP Packet from DHCP table to controller.
         """
+
         ofproto = datapath.ofproto
         parser = datapath.ofproto_parser
 
@@ -94,13 +107,14 @@ class DHCPServer(object):
         dhcp_pkt = pkt.get_protocol(dhcp.dhcp)
         request_type = ''
         opts = dhcp_pkt.options.option_list
+        msg_type = dhcp_const.OPTIONS.MESSAGE_TYPE
+        discover = struct.pack('!B', dhcp_const.REQUEST.DISCOVER)
+        offer = struct.pack('!B', dhcp_const.REQUEST.REQUEST)
         for option in opts:
-            if (option.tag == dhcp_const.OPTIONS.MESSAGE_TYPE and
-                    option.value == struct.pack('B', dhcp_const.REQUEST.DISCOVER)):
+            if option.tag == msg_type and option.value == discover:
                 request_type = REQUEST_MAPPER.DHCPDISCOVER
                 break
-            elif (option.tag == dhcp_const.OPTIONS.MESSAGE_TYPE and
-                  option.value == struct.pack('B', dhcp_const.REQUEST.REQUEST)):
+            elif option.tag == msg_type and option.value == offer:
                 request_type = REQUEST_MAPPER.DHCPREQUEST
                 break
 
@@ -130,28 +144,51 @@ class DHCPServer(object):
         else:
             return pkt.get_packet(ethernet.ethernet).src_mac
 
+    @classmethod
+    def fetch_option_for_offer(cls, pkt):
+        opts = [dhcp.option(tag=dhcp_const.OPTIONS.MESSAGE_TYPE,
+                            value=struct.pack('B', dhcp_const.REQUEST.OFFER))]
+        opts.extend(cls.fetch_options(pkt))
+        return dhcp.options(opts)
+
+    @classmethod
+    def fetch_option_for_ack(cls, pkt):
+        opts = [dhcp.option(tag=dhcp_const.OPTIONS.MESSAGE_TYPE,
+                            value=struct.pack('B', dhcp_const.REQUEST.ACK))]
+        opts.extend(cls.fetch_options(pkt))
+        return dhcp.options(opts)
+
     @staticmethod
-    def send_offer(pkt, datapath, in_port):
+    def fetch_options(pkt):
+        dhcp_pkt = pkt.get_protocol(dhcp.dhcp)
+        requested_params = None
+        for option in dhcp_pkt.options.option_list:
+            if option.tag == dhcp_const.OPTIONS.PARAMETER_REQUEST:
+                requested_params = option.value
+                break
+
+        if requested_params is None:
+            return []
+
+        requested_params = struct.unpack('B' * len(requested_params),
+                                         requested_params)
+
+        option_list = [dhcp.option(tag=dhcp_const.OPTIONS.LEASE_TIME,
+                                   value=struct.pack('!I', LEASE_TIME))]
+
+        for param in requested_params:
+            value = get_value(param)
+            if value:
+                packed_value = pack_option.pack(param, value)
+                option_list.append(dhcp.option(tag=param, value=packed_value))
+
+        return option_list
+
+    @classmethod
+    def send_offer(cls, pkt, datapath, in_port):
         """Sends DHCP offer request"""
         ether_pkt = pkt.get_protocol(ethernet.ethernet)
-        # fixme(thenakliman) Add database layer for customized
-        # IP assignment.
-        # ipaddr = db.get_ip(ether_pkt.src)
-        option_list = [
-            dhcp.option(tag=dhcp_const.OPTIONS.MESSAGE_TYPE,
-                        value=struct.pack('B', dhcp_const.REQUEST.OFFER)),
-            dhcp.option(tag=dhcp_const.OPTIONS.LEASE_TIME,
-                        value=struct.pack('!', LEASE_TIME)),
-            dhcp.option(tag=dhcp_const.OPTIONS.NETMASK,
-                        value=utils.get_packed_address('255.255.255.0')),
-            dhcp.option(tag=dhcp_const.OPTIONS.ROUTER,
-                        value=utils.get_packed_address(ROUTER)),
-            dhcp.option(tag=dhcp_const.OPTIONS.DNS_SERVER,
-                        value=utils.get_packed_address('8.8.8.8')),
-            dhcp.option(tag=dhcp_const.OPTIONS.SERVER_IDENTIFIER,
-                        value=utils.get_packed_address(SERVER_IP))
-        ]
-        options = dhcp.options(option_list)
+        options = cls.fetch_option_for_offer(pkt)
         dhcp_pkt = dhcp.dhcp(op=dhcp.DHCP_BOOT_REPLY, chaddr=ether_pkt.src,
                              xid=pkt.get_protocol(dhcp.dhcp).xid,
                              yiaddr=YIP,
@@ -159,13 +196,17 @@ class DHCPServer(object):
                              options=options)
 
         protocol_stacked = (
-            packet_util.get_ether_pkt(src=SERVER_MAC, dst=const.BROADCAST_MAC),
-            packet_util.get_ip_pkt(src=SERVER_IP, dst=const.BROADCAST_IP, proto=17),
+            packet_util.get_ether_pkt(src=SERVER_MAC,
+                                      dst=const.BROADCAST_MAC),
+            packet_util.get_ip_pkt(src=SERVER_IP,
+                                   dst=const.BROADCAST_IP, proto=17),
             packet_util.get_udp_pkt(src_port=dhcp_const.PORTS.SERVER_PORT,
                                     dst_port=dhcp_const.PORTS.CLIENT_PORT),
             dhcp_pkt)
 
-        packet_util.send_packet(datapath, packet_util.get_pkt(protocol_stacked), in_port)
+        packet_util.send_packet(datapath,
+                                packet_util.get_pkt(protocol_stacked),
+                                in_port)
 
     def handle_request(self, pkt, datapath, in_port):
         """Handles DHCPREQUEST packet"""
@@ -175,22 +216,7 @@ class DHCPServer(object):
     def send_ack(cls, pkt, datapath, port):
         """Make and send DHCPACK packet"""
         src_ether_pkt = pkt.get_protocol(ethernet.ethernet)
-        option_list = [
-            dhcp.option(tag=dhcp_const.OPTIONS.MESSAGE_TYPE,
-                        value=struct.pack('B', dhcp_const.REQUEST.ACK)),
-            dhcp.option(tag=dhcp_const.OPTIONS.LEASE_TIME,
-                        value=struct.pack('I', LEASE_TIME)),
-            dhcp.option(tag=dhcp_const.OPTIONS.NETMASK,
-                        value=utils.get_packed_address(NETMASK)),
-            dhcp.option(tag=dhcp_const.OPTIONS.REQUESTED_IP,
-                        value=utils.get_packed_address(YIP)),
-            dhcp.option(tag=dhcp_const.OPTIONS.SERVER_IDENTIFIER,
-                        value=utils.get_packed_address(SERVER_IP)),
-            dhcp.option(tag=dhcp_const.OPTIONS.ROUTER,
-                        value=utils.get_packed_address(ROUTER)),
-        ]
-
-        options = dhcp.options(option_list)
+        options = cls.fetch_option_for_ack(pkt)
         dhcp_pkt = dhcp.dhcp(op=dhcp.DHCP_BOOT_REPLY, chaddr=src_ether_pkt.src,
                              yiaddr=YIP,
                              xid=pkt.get_protocol(dhcp.dhcp).xid,
@@ -205,4 +231,6 @@ class DHCPServer(object):
                                     dst_port=dhcp_const.PORTS.CLIENT_PORT),
             dhcp_pkt)
 
-        packet_util.send_packet(datapath, packet_util.get_pkt(protocol_stacked), port)
+        packet_util.send_packet(datapath,
+                                packet_util.get_pkt(protocol_stacked),
+                                port)

--- a/susan/apps/dhcp/pack_option.py
+++ b/susan/apps/dhcp/pack_option.py
@@ -1,0 +1,86 @@
+# Copyright 2017 <thenakliman@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# Their are more than 70 options currently, two category of options are
+# important therefore included, more options can be included as per
+# requirement
+
+import copy
+import struct
+
+from susan.apps.dhcp import constants as const
+from susan.common import utils
+
+
+def struct_pack(value, **kwargs):
+    frmt = kwargs.get('format', '!%ss' % max(len(value), 2))
+    return struct.pack(frmt, value)
+
+
+def pack_list_address(values, **kwargs):
+    packed_ips = []
+    for value in values:
+        packed_ips.append(pack_ip(value))
+
+    return packed_ips
+
+
+def pack_ip(value, **kwargs):
+    return utils.get_packed_address(value)
+
+pack_list_address = pack_ip
+
+
+pack_data = {
+    # Vendor Extensions
+    const.OPTIONS.NETMASK: {'method': pack_ip},
+    const.OPTIONS.ROUTER: {'method': pack_list_address},
+    const.OPTIONS.TIME_SERVER: {'method': pack_list_address},
+    const.OPTIONS.NAME_SERVER: {'method': pack_list_address},
+    const.OPTIONS.DNS_SERVER: {'method': pack_list_address},
+    const.OPTIONS.LOG_SERVER: {'method': pack_list_address},
+    const.OPTIONS.HOST_NAME: {},
+    const.OPTIONS.BOOT_FILE: {'format': '!i'},
+    const.OPTIONS.DOMAIN_NAME: {},
+
+    # IP Layer parameter per interface
+    const.OPTIONS.MTU: {'format': '!H'},
+    const.OPTIONS.BROADCAST_ADDR: {'method': pack_ip},
+
+    # DHCP EXTENSIONS
+    const.OPTIONS.REQUESTED_IP: {'method': pack_ip},
+    const.OPTIONS.LEASE_TIME: {'format': '!L'},
+    const.OPTIONS.MESSAGE_TYPE: {'format': '!B'},
+    const.OPTIONS.SERVER_IDENTIFIER: {'method': pack_ip},
+    # Should not be filled by server
+    const.OPTIONS.PARAMETER_REQUEST: {},
+    const.OPTIONS.MESSAGE: {},
+    const.OPTIONS.MAX_DHCP_SIZE: {'format': '!H'},
+    const.OPTIONS.RENEWEL_TIME: {'format': '!I'},
+    const.OPTIONS.REBINDING_TIME: {'format': '!I'},
+    const.OPTIONS.CLIENT_IDENTIFIER: {'min_len': 2},
+    const.OPTIONS.TFTP_SERVER_NAME: {},
+    const.OPTIONS.BOOT_FILE_NAME: {}
+}
+
+
+def pack(option, value):
+    try:
+        pack_info = copy.deepcopy(pack_data[option])
+    except KeyError:
+        return
+
+    method = pack_info.get('method', struct_pack)
+    return method(value, **pack_info)

--- a/susan/apps/dhcp/pack_option.py
+++ b/susan/apps/dhcp/pack_option.py
@@ -29,28 +29,25 @@ def struct_pack(value, **kwargs):
     return struct.pack(frmt, value)
 
 
-def pack_list_address(values, **kwargs):
-    packed_ips = []
-    for value in values:
-        packed_ips.append(pack_ip(value))
+def pack_ip(values, **kwargs):
+    if not isinstance(values, list):
+        return utils.get_packed_address(values)
+    else:
+        packed_ips = []
+        for value in values:
+            packed_ips.append(utils.get_packed_address(value))
 
-    return packed_ips
-
-
-def pack_ip(value, **kwargs):
-    return utils.get_packed_address(value)
-
-pack_list_address = pack_ip
+        return packed_ips
 
 
 pack_data = {
     # Vendor Extensions
     const.OPTIONS.NETMASK: {'method': pack_ip},
-    const.OPTIONS.ROUTER: {'method': pack_list_address},
-    const.OPTIONS.TIME_SERVER: {'method': pack_list_address},
-    const.OPTIONS.NAME_SERVER: {'method': pack_list_address},
-    const.OPTIONS.DNS_SERVER: {'method': pack_list_address},
-    const.OPTIONS.LOG_SERVER: {'method': pack_list_address},
+    const.OPTIONS.ROUTER: {'method': pack_ip},
+    const.OPTIONS.TIME_SERVER: {'method': pack_ip},
+    const.OPTIONS.NAME_SERVER: {'method': pack_ip},
+    const.OPTIONS.DNS_SERVER: {'method': pack_ip},
+    const.OPTIONS.LOG_SERVER: {'method': pack_ip},
     const.OPTIONS.HOST_NAME: {},
     const.OPTIONS.BOOT_FILE: {'format': '!i'},
     const.OPTIONS.DOMAIN_NAME: {},

--- a/susan/apps/manager.py
+++ b/susan/apps/manager.py
@@ -27,6 +27,7 @@ from susan.common import packet as packet_util
 class AppManager(app_manager.RyuApp):
     """Takes care of all the applications and management of them."""
     OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
+
     def __init__(self, *args, **kwargs):
         super(AppManager, self).__init__(*args, **kwargs)
         self.apps = []
@@ -52,7 +53,6 @@ class AppManager(app_manager.RyuApp):
         datapath.send_msg(req)
         self.apps.append((dhcp.DHCPServer.matcher,
                           dhcp.DHCPServer(datapath).process_packet))
-
 
     def register(self, match, callback):
         """Registers an application to be managed by AppManager"""

--- a/susan/common/matcher.py
+++ b/susan/common/matcher.py
@@ -16,9 +16,11 @@
 from ryu.lib.packet import tcp
 from ryu.lib.packet import udp
 
+
 def is_valid_port(port):
     """Validates whether a port is None or now"""
     return bool(port is not None)
+
 
 def is_src_port(pkt, port):
     """Matches tcp/udp source port of a packet"""

--- a/susan/common/packet.py
+++ b/susan/common/packet.py
@@ -38,7 +38,6 @@ def send_packet(datapath, pkt, port=None):
     datapath.send_msg(out)
 
 
-
 def get_ether_pkt(src, dst, ethertype=ether.ETH_TYPE_IP):
     """Creates a Ether packet"""
     return ethernet.ethernet(src=src, dst=dst, ethertype=ethertype)


### PR DESCRIPTION
LEASE Time and message type is not received in the list but
without these parameters, proccedure does not work correctly.

Without LEASE time client rejects the offered ip address. And
without message type DHCP protocol was not identified by wireshark
but rather botop was being identified therefor message type was
set, even if is not requested and wireshark now correctly identify
packet type.